### PR TITLE
Added Russian (ru) language support

### DIFF
--- a/src/saa/luga/ru/__init__.py
+++ b/src/saa/luga/ru/__init__.py
@@ -7,16 +7,11 @@ from saa.core.language import Luga
 class Russian(Luga):
     time = {
         "to": "{hour} {minute}",
+        "to_zero": "{hour} ноль time_indicator",
+        "one": "час {minute}",
+        "one_zero": "час ноль time_indicator",
         0: "{hour} time_indicator",
-        1: "{hour} ноль одна",
-        2: "{hour} ноль две",
-        3: "{hour} ноль три",
-        4: "{hour} ноль четыре",
         5: "пять минут time_indicator",
-        6: "{hour} ноль шесть",
-        7: "{hour} ноль семь",
-        8: "{hour} ноль восемь",
-        9: "{hour} ноль девять",
         10: "десять минут time_indicator",
         15: "пятнадцать минут time_indicator",
         20: "двадцать минут time_indicator",
@@ -84,6 +79,7 @@ class Russian(Luga):
 
     @staticmethod
     def time_logic(hour: int, minute: int) -> tuple[int, int, str, str]:
+        is_to = "to"
         time_indicator = Russian.num_text(hour, ["час", "часа", "часов"])
 
         if hour == 0:
@@ -94,6 +90,9 @@ class Russian(Luga):
 
         if hour > 12:
             hour -= 12
+
+        if hour == 1:
+            is_to = "one"
 
         if minute == 0:
             time_indicator = Russian.num_text(hour, ["час", "часа", "часов"])
@@ -106,7 +105,20 @@ class Russian(Luga):
             else:
                 time_indicator = "{hour}"
 
-        return hour, minute, "to", time_indicator
+        elif minute < 10:
+            if minute == 1:
+                time_indicator = "одна"
+            elif minute == 2:
+                time_indicator = "две"
+            else:
+                time_indicator = "{minute}"
+
+            if hour == 1:
+                is_to = "one_zero"
+            else:
+                is_to = "to_zero"
+
+        return hour, minute, is_to, time_indicator
 
     @staticmethod
     def post_logic(text: str) -> str:

--- a/src/saa/luga/ru/__init__.py
+++ b/src/saa/luga/ru/__init__.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+
+from saa.core.language import Luga
+
+
+@dataclass(init=False, eq=False, repr=False, frozen=False)
+class Russian(Luga):
+    time = {
+        "to": "{hour} {minute}",
+        0: "{hour} time_indicator",
+        1: "{hour} ноль одна",
+        2: "{hour} ноль две",
+        3: "{hour} ноль три",
+        4: "{hour} ноль четыре",
+        5: "пять минут time_indicator",
+        6: "{hour} ноль шесть",
+        7: "{hour} ноль семь",
+        8: "{hour} ноль восемь",
+        9: "{hour} ноль девять",
+        10: "десять минут time_indicator",
+        15: "пятнадцать минут time_indicator",
+        20: "двадцать минут time_indicator",
+        30: "половина time_indicator",
+        40: "без двадцати time_indicator",
+        45: "без пятнадцати time_indicator",
+        50: "без десяти time_indicator",
+        55: "без пяти time_indicator",
+    }
+
+    number_connector = ""
+    connect_format = "{0} {2}"
+    numbers = {
+        0: "ноль",
+        1: "один",
+        2: "два",
+        3: "три",
+        4: "четыре",
+        5: "пять",
+        6: "шесть",
+        7: "семь",
+        8: "восемь",
+        9: "девять",
+        10: "десять",
+        11: "одиннадцать",
+        12: "двенадцать",
+        13: "тринадцать",
+        14: "четырнадцать",
+        15: "пятнадцать",
+        16: "шестнадцать",
+        17: "семнадцать",
+        18: "восемнадцать",
+        19: "девятнадцать",
+        20: "двадцать",
+        30: "тридцать",
+        40: "сорок",
+        50: "пятьдесят",
+    }
+
+    hour_endings = {
+        0: "двенадцатого",
+        1: "первого",
+        2: "второго",
+        3: "третьего",
+        4: "четвертого",
+        5: "пятого",
+        6: "шестого",
+        7: "седьмого",
+        8: "восьмого",
+        9: "девятого",
+        10: "десятого",
+        11: "одиннадцатого",
+        12: "двенадцатого",
+    }
+
+    @staticmethod
+    def num_text(num: int, texts: list[str]) -> str:
+        last_digit = num % 10
+        if 10 <= num <= 20 or last_digit == 0 or 5 <= last_digit <= 9:
+            return texts[2]
+        elif last_digit == 1:
+            return texts[0]
+
+        return texts[1]
+
+    @staticmethod
+    def time_logic(hour: int, minute: int) -> tuple[int, int, str, str]:
+        time_indicator = Russian.num_text(hour, ["час", "часа", "часов"])
+
+        if hour == 0:
+            hour = 12
+
+        if minute in [5, 10, 15, 20, 30, 40, 45, 50, 55]:
+            hour += 1
+
+        if hour > 12:
+            hour -= 12
+
+        if minute == 0:
+            time_indicator = Russian.num_text(hour, ["час", "часа", "часов"])
+
+        elif minute in Russian.time:
+            if minute <= 30:
+                time_indicator = Russian.hour_endings[hour]
+            elif hour == 1:
+                time_indicator = "час"
+            else:
+                time_indicator = "{hour}"
+
+        return hour, minute, "to", time_indicator
+
+    @staticmethod
+    def post_logic(text: str) -> str:
+        return text
+
+
+class Language(Russian):
+    pass

--- a/tests/test_clock/test_clock_ru.py
+++ b/tests/test_clock/test_clock_ru.py
@@ -1,0 +1,44 @@
+from datetime import time
+
+import pytest
+from saa.core.plugins import supported_languages
+from saa.core.watch import Watch
+
+Russian = supported_languages.get("ru")
+
+test_cases = [
+    (time(hour=2, minute=0), Russian, "два часа"),
+    (time(hour=5, minute=0), Russian, "пять часов"),
+    (time(hour=12, minute=50), Russian, "без десяти час"),
+    (time(hour=12, minute=55), Russian, "без пяти час"),
+    (time(hour=13, minute=0), Russian, "один час"),
+    (time(hour=13, minute=5), Russian, "пять минут второго"),
+    (time(hour=13, minute=15), Russian, "пятнадцать минут второго"),
+    (time(hour=13, minute=20), Russian, "двадцать минут второго"),
+    (time(hour=13, minute=30), Russian, "половина второго"),
+    (time(hour=13, minute=40), Russian, "без двадцати два"),
+    (time(hour=13, minute=45), Russian, "без пятнадцати два"),
+    (time(hour=13, minute=50), Russian, "без десяти два"),
+    (time(hour=13, minute=55), Russian, "без пяти два"),
+]
+
+
+@pytest.mark.parametrize("test_input, language, test_output", test_cases)
+def test_clocks(test_input, language, test_output):
+    clock = Watch(language=language)
+    assert test_output == clock(test_input)
+
+
+test_plural_cases = [
+    (time(hour=12, minute=17), Russian, "двенадцать семнадцать"),
+    (time(hour=12, minute=26), Russian, "двенадцать двадцать шесть"),
+    (time(hour=13, minute=1), Russian, "час ноль одна"),
+    (time(hour=13, minute=2), Russian, "час ноль две"),
+    (time(hour=13, minute=11), Russian, "час одиннадцать"),
+]
+
+
+@pytest.mark.parametrize("test_input, language, test_output", test_plural_cases)
+def test_cases(test_input, language, test_output):
+    clock = Watch(language=language)
+    assert test_output == clock(test_input)

--- a/tests/test_numbers/test_numbers_ru.py
+++ b/tests/test_numbers/test_numbers_ru.py
@@ -1,0 +1,16 @@
+import pytest
+from saa.core.numbers import Converter
+from saa.core.plugins import supported_languages
+
+Russian = supported_languages.get("ru")
+test_cases = [
+    (45, Russian, "сорок пять"),
+    (13, Russian, "тринадцать"),
+    (7, Russian, "семь"),
+]
+
+
+@pytest.mark.parametrize("test_input, language, test_output", test_cases)
+def test_numbers(test_input, language, test_output):
+    convert = Converter(language=language)
+    assert test_output == convert(test_input)


### PR DESCRIPTION
Added support for the Russian language, as time is typically spoken in Russian-speaking countries.

The issue is that in many Slavic languages, the word for "hour" also changes depending on the numeral. 
I had to come up with something in the code. :)